### PR TITLE
Support the password reset flow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,3 @@
 {
-    "jest.pathToJest": "node_modules/.bin/jest",
-    "jest.rootPath": "oneapp-server",
     "terminal.integrated.shell.windows": "C:\\Program Files\\Git\\bin\\bash.exe",
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,7 @@ applications:
     OPTIMIZE_MEMORY: true
   services:
     - usds-nj-oneapp-dev-db
+    - usds-nj-oneapp-dev-smtp
 
 - name: usds-nj-oneapp-staging-web
   path: ./oneapp-web/dist

--- a/oneapp-server/.vscode/settings.json
+++ b/oneapp-server/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "jest.pathToJest": "node_modules/.bin/jest",
+    "jest.rootPath": "oneapp-server"
+}

--- a/oneapp-server/__mocks__/email.config.js
+++ b/oneapp-server/__mocks__/email.config.js
@@ -1,0 +1,9 @@
+const createTransporter = async () => {
+  return {
+    sendMail: async () => {
+      return {messageId: 'mock-sent-message-id'}
+    }
+  };
+}
+
+module.exports = { createTransporter };

--- a/oneapp-server/config/custom-environment-variables.json
+++ b/oneapp-server/config/custom-environment-variables.json
@@ -8,5 +8,13 @@
     },
     "server": {
         "port": "PORT"
+    },
+    "smtp": {
+        "host": "SMTP_HOST",
+        "port": "SMTP_PORT",
+        "user": "SMTP_USER",
+        "pass": "SMTP_PASS",
+        "secure": "SMTP_SECURE",
+        "debug": "SMTP_DEBUG"
     }
 }

--- a/oneapp-server/config/default.json
+++ b/oneapp-server/config/default.json
@@ -25,5 +25,11 @@
         "pass": "",
         "secure": false,
         "debug": false
+    },
+    "emails": {
+        "passwordReset": {
+            "from": "DoNotReply@dhs.state.nj.us",
+            "subject": "NJ OneApp Password Reset."
+        }
     }
 }

--- a/oneapp-server/config/default.json
+++ b/oneapp-server/config/default.json
@@ -26,7 +26,7 @@
         "secure": false,
         "debug": false
     },
-    "emails": {
+    "email": {
         "passwordReset": {
             "from": "DoNotReply@dhs.state.nj.us",
             "subject": "NJ OneApp Password Reset."
@@ -39,5 +39,12 @@
         "lowercase": true,
         "uppercase": true,
         "excludeSimilarCharacters": true
+    },
+    "url": {
+        "host": "http://localhost:8080",
+        "path": {
+            "signIn": "/sign-in",
+            "resetPassword": "/reset-password"
+        }
     }
 }

--- a/oneapp-server/config/default.json
+++ b/oneapp-server/config/default.json
@@ -31,5 +31,13 @@
             "from": "DoNotReply@dhs.state.nj.us",
             "subject": "NJ OneApp Password Reset."
         }
+    },
+    "passwordGeneratorPolicy": {
+        "length": 15,
+        "numbers": true,
+        "symbols": false,
+        "lowercase": true,
+        "uppercase": true,
+        "excludeSimilarCharacters": true
     }
 }

--- a/oneapp-server/config/default.json
+++ b/oneapp-server/config/default.json
@@ -17,5 +17,13 @@
     "server": {
         "port": 4000,
         "path": "/"
+    },
+    "smtp": {
+        "host": "",
+        "port": 587,
+        "user": "",
+        "pass": "",
+        "secure": false,
+        "debug": false
     }
 }

--- a/oneapp-server/dao/TranslationDao.js
+++ b/oneapp-server/dao/TranslationDao.js
@@ -32,6 +32,16 @@ class TranslationDao extends SQLDataSource {
       .first()
       .cache(60 * 60);
   }
+
+  /**
+   * Get the translated text only for a given TEXT_ID and langIndex
+   * @param {*} TEXT_ID
+   * @param {*} langIndex
+   */
+  async getTranslationText(TEXT_ID, langIndex) {
+    const translation = await this.getTranslation(TEXT_ID, langIndex, ['TEXT']);
+    return translation.TEXT;
+  }
 }
 
 module.exports = TranslationDao;

--- a/oneapp-server/email.config.js
+++ b/oneapp-server/email.config.js
@@ -1,0 +1,29 @@
+const nodemailer = require('nodemailer');
+const config = require('config');
+const { get } = require('lodash');
+
+let transporter;
+
+const createTransporter = async () => {
+  // Only create the transporter once
+  if (transporter) {
+    return transporter;
+  }
+
+  // Create a test account on ethereal.email when using debug mode
+  const debug = config.get('smtp.debug');
+  const testAccount = debug ? await nodemailer.createTestAccount() : undefined;
+
+  return nodemailer.createTransport({
+    host: config.get('smtp.host'),
+    port: config.get('smtp.port'),
+    secure: config.get('smtp.secure'),
+    auth: {
+      // Authenticate with the testAccount, if created, otherwise use the config value
+      user: get(testAccount, 'user', config.get('smtp.user')),
+      pass: get(testAccount, 'pass', config.get('smtp.pass')),
+    },
+  });
+};
+
+module.exports = { createTransporter };

--- a/oneapp-server/email.config.js
+++ b/oneapp-server/email.config.js
@@ -1,6 +1,8 @@
 const nodemailer = require('nodemailer');
 const config = require('config');
 const { get } = require('lodash');
+const yn = require('yn');
+const logger = require('./logger.config');
 
 let transporter;
 
@@ -11,19 +13,20 @@ const createTransporter = async () => {
   }
 
   // Create a test account on ethereal.email when using debug mode
-  const debug = config.get('smtp.debug');
+  const debug = yn(config.get('smtp.debug'));
   const testAccount = debug ? await nodemailer.createTestAccount() : undefined;
-
-  return nodemailer.createTransport({
+  const options = {
     host: config.get('smtp.host'),
     port: config.get('smtp.port'),
-    secure: config.get('smtp.secure'),
+    secure: yn(config.get('smtp.secure')),
     auth: {
       // Authenticate with the testAccount, if created, otherwise use the config value
       user: get(testAccount, 'user', config.get('smtp.user')),
       pass: get(testAccount, 'pass', config.get('smtp.pass')),
     },
-  });
+  };
+  logger.info(options, 'Creating nodemailer transporter');
+  return nodemailer.createTransport(options);
 };
 
 module.exports = { createTransporter };

--- a/oneapp-server/logger.config.js
+++ b/oneapp-server/logger.config.js
@@ -1,8 +1,16 @@
 const pino = require('pino');
 
 const logger = pino({
+  name: 'oneapp-server',
   level: process.env.LOG_LEVEL || 'info',
   enabled: !(process.env.LOG_ENABLED === 'false'),
+  // Remove sensitive information from logs
+  redact: {
+    paths: [
+      'auth.user',
+      'auth.pass',
+    ],
+  },
 });
 
 module.exports = logger;

--- a/oneapp-server/package.json
+++ b/oneapp-server/package.json
@@ -41,6 +41,7 @@
     "oracledb": "file:lib/oracledb-5.0.0.tgz",
     "pino": "^6.7.0",
     "require-directory": "^2.1.1",
+    "string-template": "^1.0.0",
     "yargs": "^16.1.0",
     "yn": "^4.0.0"
   },

--- a/oneapp-server/package.json
+++ b/oneapp-server/package.json
@@ -40,7 +40,8 @@
     "oracledb": "file:lib/oracledb-5.0.0.tgz",
     "pino": "^6.7.0",
     "require-directory": "^2.1.1",
-    "yargs": "^16.1.0"
+    "yargs": "^16.1.0",
+    "yn": "^4.0.0"
   },
   "devDependencies": {
     "apollo-server-testing": "^2.18.2",

--- a/oneapp-server/package.json
+++ b/oneapp-server/package.json
@@ -36,6 +36,7 @@
     "jsonwebtoken": "^8.5.1",
     "knex": "^0.21.6",
     "lodash": "^4.17.19",
+    "nodemailer": "^6.4.14",
     "oracledb": "file:lib/oracledb-5.0.0.tgz",
     "pino": "^6.7.0",
     "require-directory": "^2.1.1",

--- a/oneapp-server/package.json
+++ b/oneapp-server/package.json
@@ -25,6 +25,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-jwt": "^6.0.0",
+    "generate-password": "^1.5.1",
     "graphql": "^15.3.0",
     "graphql-constraint-directive": "^2.1.0",
     "graphql-iso-date": "^3.6.1",

--- a/oneapp-server/services/AuthenticationService.js
+++ b/oneapp-server/services/AuthenticationService.js
@@ -12,13 +12,13 @@ const rules = {
       return hasAuthenticatedUser;
     },
   ),
-  rateLimit: createRateLimitRule({
+  rateLimit: (options) => createRateLimitRule({
     // Rate limit context is a hybrid of requestIP and authenticated user
     identifyContext: (ctx) => ({
       auth: ctx.auth,
       requestIP: ctx.requestIP,
     }),
-  }),
+  })(options),
 };
 
 const service = {

--- a/oneapp-server/services/EmailService.js
+++ b/oneapp-server/services/EmailService.js
@@ -1,0 +1,17 @@
+const nodemailer = require('nodemailer');
+const config = require('config');
+const { createTransporter } = require('../email.config');
+const logger = require('../logger.config');
+
+const service = {
+  sendEmail: async (message) => {
+    const transporter = await createTransporter();
+    const info = await transporter.sendMail(message);
+    logger.debug('Email sent with messageId=%s', info.messageId);
+    if (config.get('smtp.debug')) {
+      logger.info('Email preview URL: %s', nodemailer.getTestMessageUrl(info));
+    }
+  },
+};
+
+module.exports = service;

--- a/oneapp-server/services/EmailService.test.js
+++ b/oneapp-server/services/EmailService.test.js
@@ -1,0 +1,33 @@
+const EmailService = require('./EmailService');
+const logger = require('../logger.config');
+const config = require('config');
+const nodemailer = require('nodemailer');
+
+jest.mock('../logger.config');
+jest.mock('../email.config');
+jest.mock('config');
+jest.mock('nodemailer');
+
+describe('EmailService sendEmail', () => {
+  it('sends an email and logs the messageId', async () => {
+    await EmailService.sendEmail({to: 'test'});
+    expect(logger.debug).toHaveBeenCalledWith('Email sent with messageId=%s', 'mock-sent-message-id');
+  });
+
+  it('logs the preview email URL when debug is enabled', async () => {
+    config.get.mockImplementation(prop => {
+      switch (prop) {
+        case 'smtp.debug':
+          return true;
+        default:
+          return undefined;
+      }
+    });
+
+    nodemailer.getTestMessageUrl.mockReturnValue('https://test.email');
+
+    await EmailService.sendEmail({to: 'test'});
+    expect(nodemailer.getTestMessageUrl).toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith('Email preview URL: %s', 'https://test.email');
+  });
+});

--- a/oneapp-server/services/__mocks__/index.js
+++ b/oneapp-server/services/__mocks__/index.js
@@ -1,1 +1,0 @@
-module.exports = require('require-directory')(module, { recurse: false, exclude: /\.test\.js/ });

--- a/oneapp-server/services/index.js
+++ b/oneapp-server/services/index.js
@@ -1,1 +1,6 @@
-module.exports = require('require-directory')(module, { recurse: false, exclude: /\.test\.js/ });
+const { assign } = require('lodash');
+
+const services = require('require-directory')(module, { recurse: false, exclude: /\.test\.js/ });
+const mockServices = require('require-directory')(module, './__mocks__', { recurse: false, exclude: /\.test\.js/ });
+
+module.exports = assign({}, services, mockServices);

--- a/oneapp-server/types/User.js
+++ b/oneapp-server/types/User.js
@@ -109,7 +109,7 @@ const permissions = {
     users: allow,
   },
   Mutation: {
-    userAuthenticate: allow,
+    userAuthenticate: AuthenticationService.rules.rateLimit({ window: '1m', max: 20 }),
     userRegister: allow,
   },
   JwtToken: allow,

--- a/oneapp-server/types/User.js
+++ b/oneapp-server/types/User.js
@@ -2,6 +2,7 @@ const { gql } = require('apollo-server-express');
 const { allow } = require('graphql-shield');
 const _ = require('lodash');
 const config = require('config');
+const passwordGenerator = require('generate-password');
 const AuthenticationService = require('../services/AuthenticationService');
 const { OneAppError, OneAppUserInputError } = require('../utils/OneAppError');
 
@@ -78,7 +79,7 @@ const resolvers = {
       });
     },
     userPasswordReset: async (_parent, { USER_ID, HINT_ANSWER }, { dataSources, services }) => {
-      const randomPassword = 'genme';
+      const randomPassword = passwordGenerator.generate(config.util.toObject(config.get('passwordGeneratorPolicy')));
       const response = await dataSources.UserDao.resetUserPassword(USER_ID, HINT_ANSWER, randomPassword);
       const user = response[0];
       const responseCode = parseInt(response[1], 10);
@@ -97,6 +98,7 @@ const resolvers = {
       } else {
         throw new OneAppUserInputError('Answers did not match.', 't2256');
       }
+      return true;
     },
   },
   Users: {

--- a/oneapp-server/types/User.js
+++ b/oneapp-server/types/User.js
@@ -1,8 +1,9 @@
 const { gql } = require('apollo-server-express');
 const { allow } = require('graphql-shield');
 const _ = require('lodash');
+const config = require('config');
 const AuthenticationService = require('../services/AuthenticationService');
-const { OneAppError } = require('../utils/OneAppError');
+const { OneAppError, OneAppUserInputError } = require('../utils/OneAppError');
 
 const typeDef = gql`
   extend type Query {
@@ -12,6 +13,7 @@ const typeDef = gql`
   extend type Mutation {
     userAuthenticate(input: UserLogin!): JwtToken
     userRegister(input: UserInput!): JwtToken
+    userPasswordReset(USER_ID: String!, HINT_ANSWER: String!): Boolean
   }
 
   type Users {
@@ -75,6 +77,27 @@ const resolvers = {
         EMAIL_ADDRESS: user.EMAIL_ADDRESS,
       });
     },
+    userPasswordReset: async (_parent, { USER_ID, HINT_ANSWER }, { dataSources, services }) => {
+      const randomPassword = 'genme';
+      const response = await dataSources.UserDao.resetUserPassword(USER_ID, HINT_ANSWER, randomPassword);
+      const user = response[0];
+      const responseCode = parseInt(response[1], 10);
+
+      // Handle password successfully changed
+      if (responseCode === 1) {
+        const message = {
+          from: config.get('emails.passwordReset.from'),
+          to: user.EMAIL_ADDRESS,
+          subject: config.get('emails.passwordReset.subject'),
+          html: user.PASSWORD,
+        };
+        await services.EmailService.sendEmail(message);
+      } else if (responseCode === -2) {
+        throw new OneAppError('User account locked.', 't2259');
+      } else {
+        throw new OneAppUserInputError('Answers did not match.', 't2256');
+      }
+    },
   },
   Users: {
     current: (_parent, _args, { auth, dataSources }) => dataSources.UserDao.getUser(auth.user.USER_ID),
@@ -111,6 +134,7 @@ const permissions = {
   Mutation: {
     userAuthenticate: AuthenticationService.rules.rateLimit({ window: '1m', max: 20 }),
     userRegister: allow,
+    userPasswordReset: AuthenticationService.rules.rateLimit({ window: '1m', max: 20 }),
   },
   JwtToken: allow,
   Users: {

--- a/oneapp-server/types/User.test.js
+++ b/oneapp-server/types/User.test.js
@@ -1,3 +1,7 @@
+const { createTestClient, dataSources, services } = require('../__utils/TestingUtils');
+const client = createTestClient();
+const passwordGenerator = require('generate-password');
+
 const { resolvers } = require('./User');
 const AuthenticationService = require('../services/AuthenticationService');
 
@@ -6,6 +10,8 @@ const mockDataSources = {
     createUser: jest.fn()
   }
 };
+
+jest.mock('generate-password');
 
 test('register creates a user and returns a token', async () => {
   const mockUser = { USER_ID: 1 };
@@ -20,4 +26,56 @@ test('register creates a user and returns a token', async () => {
   expect(retVal).toBe('token');
   expect(mockDataSources.UserDao.createUser).toHaveBeenCalledWith(input);
   expect(AuthenticationService.createToken).toHaveBeenCalledWith(mockUser);
+});
+
+describe('User node', () => {
+  beforeEach(() => {
+    passwordGenerator.generate.mockReturnValue('random-password');
+  });
+
+  it('during password reset, generates a random password and sends it via email', async () => {
+    dataSources.UserDao.resetUserPassword.mockResolvedValue([{USER_ID: 'USER_ID', EMAIL_ADDRESS: 'fake@email.com'}, 1]);
+    dataSources.TranslationDao.getTranslationText.mockResolvedValue('Replace {0} and {1}');
+
+    const query = `
+      mutation {
+          userPasswordReset(USER_ID: "RKH1", HINT_ANSWER: "answer")
+      }
+    `;
+    const response = await client.query({ query });
+    expect(response.data.userPasswordReset).toBe(true);
+
+    expect(services.EmailService.sendEmail).toHaveBeenCalledWith({
+      from: 'DoNotReply@dhs.state.nj.us',
+      to: 'fake@email.com',
+      subject: 'NJ OneApp Password Reset.',
+      html: 'Replace USER_ID and random-password'
+    });
+  });
+
+  it('during password reset, handles non-matching answers', async () => {
+    dataSources.UserDao.resetUserPassword.mockResolvedValue([{USER_ID: 'USER_ID', EMAIL_ADDRESS: 'fake@email.com'}, -50]);
+
+    const query = `
+      mutation {
+          userPasswordReset(USER_ID: "RKH1", HINT_ANSWER: "answer")
+      }
+    `;
+    const response = await client.query({ query });
+    expect(response.data.userPasswordReset).toBeNull();
+    expect(response.errors[0]).toEqual({MESSAGE_TEXT_ID: 't2256', code: 'BAD_USER_INPUT', message: 'Answers did not match.', path: ['userPasswordReset']});
+  });
+
+  it('during password reset, handles locked accounts', async () => {
+    dataSources.UserDao.resetUserPassword.mockResolvedValue([{USER_ID: 'USER_ID', EMAIL_ADDRESS: 'fake@email.com'}, -2]);
+
+    const query = `
+      mutation {
+          userPasswordReset(USER_ID: "RKH1", HINT_ANSWER: "answer")
+      }
+    `;
+    const response = await client.query({ query });
+    expect(response.data.userPasswordReset).toBeNull();
+    expect(response.errors[0]).toEqual({MESSAGE_TEXT_ID: 't2259', code: 'OneAppError', message: 'User account locked.', path: ['userPasswordReset']});
+  });
 });

--- a/oneapp-server/yarn.lock
+++ b/oneapp-server/yarn.lock
@@ -8417,6 +8417,11 @@ yargs@^16.1.0:
     y18n "^5.0.2"
     yargs-parser "^20.2.2"
 
+yn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-4.0.0.tgz#611480051ea43b510da1dfdbe177ed159f00a979"
+  integrity sha512-huWiiCS4TxKc4SfgmTwW1K7JmXPPAmuXWYy4j9qjQo4+27Kni8mGhAAi1cloRWmBe2EqcLgt3IGqQoRL/MtPgg==
+
 yup@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/yup/-/yup-0.27.0.tgz#f8cb198c8e7dd2124beddc2457571329096b06e7"

--- a/oneapp-server/yarn.lock
+++ b/oneapp-server/yarn.lock
@@ -7462,6 +7462,11 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-template@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string-template/-/string-template-1.0.0.tgz#9e9f2233dc00f218718ec379a28a5673ecca8b96"
+  integrity sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=
+
 string-width@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"

--- a/oneapp-server/yarn.lock
+++ b/oneapp-server/yarn.lock
@@ -5958,6 +5958,11 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
+nodemailer@^6.4.14:
+  version "6.4.14"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.4.14.tgz#2ffb160b63ff0c15a979da75e1f82af85433d2a3"
+  integrity sha512-0AQHOOT+nRAOK6QnksNaK7+5vjviVvEBzmZytKU7XSA+Vze2NLykTx/05ti1uJgXFTWrMq08u3j3x4r4OE6PAA==
+
 nodemon@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.5.tgz#df67fe1fd1312ddb0c1e393ae2cf55aacdcec2f3"

--- a/oneapp-server/yarn.lock
+++ b/oneapp-server/yarn.lock
@@ -3892,6 +3892,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+generate-password@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/generate-password/-/generate-password-1.5.1.tgz#ad463fadee1b4818edb7b827ff6f3499587d8dd5"
+  integrity sha512-XdsyfiF4mKoOEuzA44w9jSNav50zOurdWOV3V8DbA7SJIxR3Xm9ob14HKYTnMQOPX3ylqiJMnQF0wEa8gXZIMw==
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"


### PR DESCRIPTION
* Adds an EmailService that can be used in any GraphQL node
* Uses ethereal.email as a fallback for dev testing (when lacking a real SMTP email server)
* Adds password generator with a configurable password policy
* Fixes an issue where the stored procedures are expecting all user input values to be uppercase

Follow up before ready for merge:
* [x] Actually test this work (beyond the unit tests)
* [x] Configure our staging server to send emails