### PR TITLE
297: Application GraphQL type

### DIFF
--- a/oneapp-server/types/Application.js
+++ b/oneapp-server/types/Application.js
@@ -1,0 +1,25 @@
+const { gql } = require('apollo-server-express');
+
+const typeDef = gql`
+  extend type Query {
+    "Safety net benefits application for SNAP, TANF, GA"
+    application: Application
+  }
+
+  type Application {
+    "The id of the application. This will be the same as the user id."
+    APPLICATION_NUMBER: ID
+  }
+`;
+
+const resolvers = {
+  Query: {
+    application: () => ({}),
+  },
+};
+
+const permissions = {
+
+};
+
+module.exports = { typeDef, resolvers, permissions };

--- a/oneapp-server/types/ApplicationContact.js
+++ b/oneapp-server/types/ApplicationContact.js
@@ -1,0 +1,24 @@
+const { gql } = require('apollo-server-express');
+
+const typeDef = gql`
+  extend type Application {
+    "The individual applying for benefits"
+    contact: ApplicationContact
+  }
+
+  type ApplicationContact {
+    APPLICATION_FIRST_NAME: String
+  }
+`;
+
+const resolvers = {
+  Application: {
+    contact: () => ({}),
+  },
+};
+
+const permissions = {
+
+};
+
+module.exports = { typeDef, resolvers, permissions };

--- a/oneapp-server/types/ApplicationContact.js
+++ b/oneapp-server/types/ApplicationContact.js
@@ -7,35 +7,74 @@ const typeDef = gql`
   }
 
   type ApplicationContact {
+    "Applicant first name"
     APPLICANT_FIRST_NAME: String
+    "Applicant last name"
     APPLICANT_LAST_NAME: String
+    "Applicant middle name"
     APPLICANT_MIDDLE_NAME: String
+    "Application maiden name"
     APPLICANT_MAIDEN_NAME: String
+    "Payee first name, if different than applicant"
     PAYEE_FIRST_NAME: String
+    "Payee last name, if different than applicant"
     PAYEE_LAST_NAME: String
+    "Is applicant homeless"
     IS_HOMELESS: Boolean
+    "Applicant address line 1"
     ADDRESS1: String
+    "Applicant address line 2"
     ADDRESS2: String
+    "Applicant address city"
     CITY: String
+    "Applicant address state"
     STATE: String
+    "Applicant address zipcode"
     ZIP: Int
+    "Applicant address zipcode extend 4"
     ZIP4: Int
+    "New Jersey county id, retrieved from zipcode to county lookup"
     COUNTY_NUMBER: Int
+    "Mailing address line 1"
     M_ADDRESS1: String
+    "Mailing address line 2"
     M_ADDRESS2: String
+    "Mailing address city"
     M_CITY: String
+    "Mailing address state"
     M_STATE: String
+    "Mailing address zipcode"
     M_ZIP: Int
+    "Mailing address zipcode extended 4"
     M_ZIP4: Int
+    "Applicant home phone number"
     HOME_PHONE_NUMBER: Int
+    "Applicant work phone number"
     WORK_PHONE_NUMBER: Int
+    "Applicant cell phone number"
     CELL_PHONE_NUMBER: Int
+    "Applicant other phone number"
     OTHER_PHONE_NUMBER: Int
+    "Applicant email address"
     EMAIL_ADDRESS: String
+    "Does applicant not have a phone number"
     NO_PHONE_NUMBER: Boolean
+    "Does applicant not have contact information"
     NO_CONTACT_INFORMATION: Boolean
-    APPLICATION_TYPE: Int
-    APPLICATION_SUBTYPE: Int
+    "The source of the application; always OA"
+    APPLICATION_TYPE: ApplicationType
+    "Is special New Jersey Help application; can be null"
+    APPLICATION_SUBTYPE: ApplicationSubtype
+  }
+
+  enum ApplicationType {
+    "OneApp"
+    OA
+  }
+
+  enum ApplicationSubtype {
+    "New Jersey Helps"
+    NJHE
   }
 `;
 

--- a/oneapp-server/types/ApplicationContact.js
+++ b/oneapp-server/types/ApplicationContact.js
@@ -7,7 +7,35 @@ const typeDef = gql`
   }
 
   type ApplicationContact {
-    APPLICATION_FIRST_NAME: String
+    APPLICANT_FIRST_NAME: String
+    APPLICANT_LAST_NAME: String
+    APPLICANT_MIDDLE_NAME: String
+    APPLICANT_MAIDEN_NAME: String
+    PAYEE_FIRST_NAME: String
+    PAYEE_LAST_NAME: String
+    IS_HOMELESS: Boolean
+    ADDRESS1: String
+    ADDRESS2: String
+    CITY: String
+    STATE: String
+    ZIP: Int
+    ZIP4: Int
+    COUNTY_NUMBER: Int
+    M_ADDRESS1: String
+    M_ADDRESS2: String
+    M_CITY: String
+    M_STATE: String
+    M_ZIP: Int
+    M_ZIP4: Int
+    HOME_PHONE_NUMBER: Int
+    WORK_PHONE_NUMBER: Int
+    CELL_PHONE_NUMBER: Int
+    OTHER_PHONE_NUMBER: Int
+    EMAIL_ADDRESS: String
+    NO_PHONE_NUMBER: Boolean
+    NO_CONTACT_INFORMATION: Boolean
+    APPLICATION_TYPE: Int
+    APPLICATION_SUBTYPE: Int
   }
 `;
 

--- a/oneapp-server/types/ApplicationFoodStampInfo.js
+++ b/oneapp-server/types/ApplicationFoodStampInfo.js
@@ -7,6 +7,12 @@ const typeDef = gql`
 
   type ApplicationFoodStampInfo {
     IS_GROSS_INCOME_LT_150: Boolean
+    IS_RENT_GT_GROSS_INCOME: Boolean
+    HAS_MIGRANT_FARM_WORKER: Boolean
+    HAS_RECEIVED_EMERGENCY_FS: Boolean
+    EMERGENCY_FS_DATE: Date
+    EMERGENCY_FS_LOCATION: String
+    EMERGENCY_FS_STATE: String
   }
 `;
 

--- a/oneapp-server/types/ApplicationFoodStampInfo.js
+++ b/oneapp-server/types/ApplicationFoodStampInfo.js
@@ -1,0 +1,23 @@
+const { gql } = require('apollo-server-express');
+
+const typeDef = gql`
+  extend type Application {
+    foodStampInfo: ApplicationFoodStampInfo
+  }
+
+  type ApplicationFoodStampInfo {
+    IS_GROSS_INCOME_LT_150: Boolean
+  }
+`;
+
+const resolvers = {
+  Application: {
+    foodStampInfo: () => ({}),
+  },
+};
+
+const permissions = {
+
+};
+
+module.exports = { typeDef, resolvers, permissions };

--- a/oneapp-server/types/ApplicationFoodStampInfo.js
+++ b/oneapp-server/types/ApplicationFoodStampInfo.js
@@ -6,12 +6,19 @@ const typeDef = gql`
   }
 
   type ApplicationFoodStampInfo {
+    "Monthly household income is less than $150 a month"
     IS_GROSS_INCOME_LT_150: Boolean
+    "Rent is greater than applicant gross income"
     IS_RENT_GT_GROSS_INCOME: Boolean
+    "Applicant household has migrant farm worker"
     HAS_MIGRANT_FARM_WORKER: Boolean
+    "Household is receiving emergency foodstamps"
     HAS_RECEIVED_EMERGENCY_FS: Boolean
+    "Household received emergency foodstamps on date"
     EMERGENCY_FS_DATE: Date
+    "Household received emergency foodstamps in city"
     EMERGENCY_FS_LOCATION: String
+    "Household received emergency foodstamps in state"
     EMERGENCY_FS_STATE: String
   }
 `;

--- a/oneapp-server/types/ApplicationProgramInfo.js
+++ b/oneapp-server/types/ApplicationProgramInfo.js
@@ -1,0 +1,23 @@
+const { gql } = require('apollo-server-express');
+
+const typeDef = gql`
+  extend type Application {
+    programInfo: ApplicationProgramInfo
+  }
+
+  type ApplicationProgramInfo {
+    IS_FS_SELECTED: Boolean
+  }
+`;
+
+const resolvers = {
+  Application: {
+    programInfo: () => ({}),
+  },
+};
+
+const permissions = {
+
+};
+
+module.exports = { typeDef, resolvers, permissions };

--- a/oneapp-server/types/ApplicationProgramInfo.js
+++ b/oneapp-server/types/ApplicationProgramInfo.js
@@ -7,6 +7,21 @@ const typeDef = gql`
 
   type ApplicationProgramInfo {
     IS_FS_SELECTED: Boolean
+    IS_TF_SELECTED: Boolean
+    IS_GA_SELECTED: Boolean
+    HAVE_ACTIVE_CASE_CURRENTLY: Boolean
+    CURRENT_CASE_NUMBERS: String
+    HAD_ACTIVE_CASE_PREVIOULSY: Boolean
+    PREVIOUS_CASE_NUMBERS: String
+    SPOKEN_LANGUAGE: String
+    HAS_PAYEE: Boolean
+    NEED_ACCOMODATION: Boolean
+    NEED_ACM_TRANSLATOR: Boolean
+    NEED_ACM_SIGNING: Boolean
+    NEED_ACM_VISUALLY_IMPAIRED: Boolean
+    NEED_ACM_OTHER: Boolean
+    ACM_TRA_LANGUAGE: String
+    ACM_OTH_DESCRIPTION: String
   }
 `;
 

--- a/oneapp-server/types/ApplicationProgramInfo.js
+++ b/oneapp-server/types/ApplicationProgramInfo.js
@@ -6,21 +6,35 @@ const typeDef = gql`
   }
 
   type ApplicationProgramInfo {
+    "Applying for SNAP"
     IS_FS_SELECTED: Boolean
+    "Applying for TANF"
     IS_TF_SELECTED: Boolean
+    "Applying for General Assistance"
     IS_GA_SELECTED: Boolean
+    "Has active SNAP case"
     HAVE_ACTIVE_CASE_CURRENTLY: Boolean
+    "Case number(s) of active SNAP applications"
     CURRENT_CASE_NUMBERS: String
+    "Has received SNAP previously"
     HAD_ACTIVE_CASE_PREVIOULSY: Boolean
+    "Case number(s) of previous SNAP applications"
     PREVIOUS_CASE_NUMBERS: String
+    "Spoken language of applicant"
     SPOKEN_LANGUAGE: String
-    HAS_PAYEE: Boolean
+    "Applicant needs accommodation"
     NEED_ACCOMODATION: Boolean
+    "Needs accommodation type translator"
     NEED_ACM_TRANSLATOR: Boolean
+    "Needs accommodation type signing"
     NEED_ACM_SIGNING: Boolean
+    "Needs accommodation type visual"
     NEED_ACM_VISUALLY_IMPAIRED: Boolean
+    "Needs accommodation type other"
     NEED_ACM_OTHER: Boolean
+    "Accommodation translator language"
     ACM_TRA_LANGUAGE: String
+    "Description of other accommodation type"
     ACM_OTH_DESCRIPTION: String
   }
 `;


### PR DESCRIPTION
This model is based on the information from #296. The type structure has been setup in the GraphQL server and the fields loosely documented. Validation rules and required fields are not in place yet, they will be done in the sub-tasks for each GraphQL type (see the sub-tasks broken out in #297).

Looking for the following feedback in the review:
* The structure of the GraphQL type
  * Currently replicating the database model as closely as possible in GraphQL. This included keeping uppercase, mapping fields 1:1, and replicating typos in db field names.
* Various decision made, which are commented alongside the code in the PR