### PR TITLE
feat: Add GraphQL tests

### DIFF
--- a/oneapp-server/types/Application.test.js
+++ b/oneapp-server/types/Application.test.js
@@ -84,4 +84,112 @@ describe('applicationUpdate mutation', () => {
     const response = await authClient.query({ query });
     expect(response.errors[0].code).toEqual('GRAPHQL_VALIDATION_FAILED');
   });
+
+  it('updates both food stamp and program info', async () => {
+    const user = {USER_ID: 'user123'};
+    const authClient = createTestClient({user});
+
+    dataSources.ApplicationFoodStampInfoDao.updateFoodStampInfo.mockReturnValue(1);
+    dataSources.ApplicationProgramInfoDao.updateProgramInfo.mockReturnValue(1);
+
+    const query = `
+      mutation {
+        applicationUpdate(input: {
+          foodStampInfo: {
+            IS_GROSS_INCOME_LT_150: true,
+            IS_RENT_GT_GROSS_INCOME: true,
+            HAS_MIGRANT_FARM_WORKER: false,
+            HAS_RECEIVED_EMERGENCY_FS: true,
+            EMERGENCY_FS_DATE: "2020-01-01",
+            EMERGENCY_FS_LOCATION: "Newark",
+            EMERGENCY_FS_STATE: "NJ",
+          },
+          programInfo: {
+            IS_FS_SELECTED: true,
+            IS_TF_SELECTED: false,
+            IS_GA_SELECTED: false,
+            HAVE_ACTIVE_CASE_CURRENTLY: true,
+            CURRENT_CASE_NUMBERS: "123456",
+            HAD_ACTIVE_CASE_PREVIOULSY: true,
+            PREVIOUS_CASE_NUMBERS: "12345",
+            SPOKEN_LANGUAGE: "en",
+            NEED_ACCOMODATION: true,
+            NEED_ACM_TRANSLATOR: false,
+            NEED_ACM_SIGNING: true,
+            NEED_ACM_VISUALLY_IMPAIRED: false,
+            NEED_ACM_OTHER: false,
+          }
+        })
+      }
+    `;
+    const response = await authClient.query({ query });
+    expect(response.data.applicationUpdate).toEqual(true);
+
+    expect(dataSources.ApplicationFoodStampInfoDao.updateFoodStampInfo).toHaveBeenCalledWith(
+      "user123",
+      {
+        IS_GROSS_INCOME_LT_150: true,
+        IS_RENT_GT_GROSS_INCOME: true,
+        HAS_MIGRANT_FARM_WORKER: false,
+        HAS_RECEIVED_EMERGENCY_FS: true,
+        EMERGENCY_FS_DATE: new Date("2020-01-01"),
+        EMERGENCY_FS_LOCATION: "Newark",
+        EMERGENCY_FS_STATE: "NJ",
+      },
+    );
+
+    expect(dataSources.ApplicationProgramInfoDao.updateProgramInfo).toHaveBeenCalledWith(
+      "user123",
+      {
+        IS_FS_SELECTED: true,
+        IS_TF_SELECTED: false,
+        IS_GA_SELECTED: false,
+        HAVE_ACTIVE_CASE_CURRENTLY: true,
+        CURRENT_CASE_NUMBERS: "123456",
+        HAD_ACTIVE_CASE_PREVIOULSY: true,
+        PREVIOUS_CASE_NUMBERS: "12345",
+        SPOKEN_LANGUAGE: "en",
+        NEED_ACCOMODATION: true,
+        NEED_ACM_TRANSLATOR: false,
+        NEED_ACM_SIGNING: true,
+        NEED_ACM_VISUALLY_IMPAIRED: false,
+        NEED_ACM_OTHER: false,
+      },
+    );
+  });
+
+  it('updates TANF/GA header', async () => {
+    const user = {USER_ID: 'user123'};
+    const authClient = createTestClient({user});
+    const REASON = "A reason for moving";
+
+    dataSources.TanfGaHeaderDao.updateTanfGaHeader.mockReturnValue(1);
+
+    const query = `
+      mutation {
+        applicationUpdate(input: {
+          tanfGaHeader: {
+            WILL_SEEK_EMPLOYMENT: true,
+            WILL_REGISTER_FOR_WORK: false,
+            WILLING_TO_WORK: true,
+            WILL_CONTINUE_LIVING_IN_NJ: false,
+            WONT_CONTINUE_REASON: "A reason for moving",
+          }
+        })
+      }
+    `;
+    const response = await authClient.query({ query });
+    expect(response.data.applicationUpdate).toEqual(true);
+
+    expect(dataSources.TanfGaHeaderDao.updateTanfGaHeader).toHaveBeenCalledWith(
+      "user123",
+      {
+        WILL_SEEK_EMPLOYMENT: true,
+        WILL_REGISTER_FOR_WORK: false,
+        WILLING_TO_WORK: true,
+        WILL_CONTINUE_LIVING_IN_NJ: false,
+        WONT_CONTINUE_REASON: REASON,
+      },
+    );
+  });
 });

--- a/oneapp-server/types/ApplicationContact.test.js
+++ b/oneapp-server/types/ApplicationContact.test.js
@@ -1,11 +1,7 @@
-const { createTestClient, dataSources, services } = require('../__utils/TestingUtils');
-const client = createTestClient();
-const passwordGenerator = require('generate-password');
-
-jest.mock('generate-password');
+const { createTestClient, dataSources } = require('../__utils/TestingUtils');
 
 describe('application contact query', () => {
-  it('updates contact info', async () => {
+  it('fetches contact info', async () => {
     const user = {USER_ID: 'user123'};
     const authClient = createTestClient({user});
 

--- a/oneapp-server/types/ApplicationFoodStampInfo.js
+++ b/oneapp-server/types/ApplicationFoodStampInfo.js
@@ -42,7 +42,7 @@ const typeDef = gql`
 
 const resolvers = {
   Application: {
-    foodStampInfo: (_parent, _args, { dataSources, auth, language }) => dataSources.FoodStampInfoDao.getFoodStampInfo(auth.user.USER_ID, language.code),
+    foodStampInfo: (_parent, _args, { dataSources, auth, language }) => dataSources.ApplicationFoodStampInfoDao.getFoodStampInfo(auth.user.USER_ID, language.index),
   },
 };
 

--- a/oneapp-server/types/ApplicationFoodStampInfo.test.js
+++ b/oneapp-server/types/ApplicationFoodStampInfo.test.js
@@ -1,0 +1,37 @@
+const { createTestClient, dataSources } = require('../__utils/TestingUtils');
+
+describe('application food stamp info query', () => {
+  it('fetches food stamp info', async () => {
+    const user = {USER_ID: 'user123'};
+    const authClient = createTestClient({user});
+
+    dataSources.ApplicationFoodStampInfoDao.getFoodStampInfo.mockReturnValue({
+      IS_GROSS_INCOME_LT_150: true,
+      IS_RENT_GT_GROSS_INCOME: true,
+      HAS_MIGRANT_FARM_WORKER: false,
+      HAS_RECEIVED_EMERGENCY_FS: true,
+      EMERGENCY_FS_DATE: null,
+      EMERGENCY_FS_LOCATION: 'Newark',
+      EMERGENCY_FS_STATE: 'NJ',
+    });
+
+    const query = `
+      {
+        application {
+          foodStampInfo { 
+            HAS_RECEIVED_EMERGENCY_FS
+            EMERGENCY_FS_LOCATION
+            EMERGENCY_FS_STATE
+          }
+        }
+      } 
+    `;
+    const response = await authClient.query({ query });
+    expect(response.data.application.foodStampInfo.HAS_RECEIVED_EMERGENCY_FS).toEqual(true);
+    expect(response.data.application.foodStampInfo.EMERGENCY_FS_LOCATION).toEqual('Newark');
+    expect(dataSources.ApplicationFoodStampInfoDao.getFoodStampInfo).toHaveBeenCalledWith(
+      "user123",
+      0,
+    );
+  });
+});

--- a/oneapp-server/types/ApplicationProgramInfo.js
+++ b/oneapp-server/types/ApplicationProgramInfo.js
@@ -74,7 +74,7 @@ const typeDef = gql`
 
 const resolvers = {
   Application: {
-    programInfo: (_parent, _args, { dataSources, auth, language }) => dataSources.ApplicationProgramInfoDao.getProgramInfo(auth.user.USER_ID, language.code),
+    programInfo: (_parent, _args, { dataSources, auth, language }) => dataSources.ApplicationProgramInfoDao.getProgramInfo(auth.user.USER_ID, language.index),
   },
 };
 

--- a/oneapp-server/types/ApplicationProgramInfo.test.js
+++ b/oneapp-server/types/ApplicationProgramInfo.test.js
@@ -1,0 +1,53 @@
+const { createTestClient, dataSources } = require('../__utils/TestingUtils');
+
+describe('application program info query', () => {
+  it('fetches program info', async () => {
+    const user = {USER_ID: 'user123'};
+    const authClient = createTestClient({user});
+
+    dataSources.ApplicationProgramInfoDao.getProgramInfo.mockReturnValue({
+        IS_FS_SELECTED: true,
+        IS_TF_SELECTED: false,
+        IS_GA_SELECTED: false,
+        HAVE_ACTIVE_CASE_CURRENTLY: true,
+        CURRENT_CASE_NUMBERS: "123456",
+        HAD_ACTIVE_CASE_PREVIOULSY: true,
+        PREVIOUS_CASE_NUMBERS: "12345",
+        SPOKEN_LANGUAGE: "en",
+        NEED_ACCOMODATION: true,
+        NEED_ACM_TRANSLATOR: false,
+        NEED_ACM_SIGNING: true,
+        NEED_ACM_VISUALLY_IMPAIRED: false,
+        NEED_ACM_OTHER: false,
+    });
+
+    const query = `
+      {
+        application {
+          programInfo { 
+            IS_FS_SELECTED
+            IS_TF_SELECTED
+            IS_GA_SELECTED
+            HAVE_ACTIVE_CASE_CURRENTLY
+            CURRENT_CASE_NUMBERS
+            HAD_ACTIVE_CASE_PREVIOULSY
+            PREVIOUS_CASE_NUMBERS
+            SPOKEN_LANGUAGE
+            NEED_ACCOMODATION
+            NEED_ACM_TRANSLATOR
+            NEED_ACM_SIGNING
+            NEED_ACM_VISUALLY_IMPAIRED
+            NEED_ACM_OTHER
+          }
+        }
+      } 
+    `;
+    const response = await authClient.query({ query });
+    expect(response.data.application.programInfo.IS_FS_SELECTED).toEqual(true);
+    expect(response.data.application.programInfo.CURRENT_CASE_NUMBERS).toEqual('123456');
+    expect(dataSources.ApplicationProgramInfoDao.getProgramInfo).toHaveBeenCalledWith(
+      "user123",
+      0,
+    );
+  });
+});


### PR DESCRIPTION
Updated Application.test.js to include test cases for new sub-mutation updates

Added new tests for fetching subsections of the larger application (i.e. FoodStampInfo, ProgramInfo)